### PR TITLE
Separate mod loading into multiple functions

### DIFF
--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -58,6 +58,8 @@ Mod::Mod(fs::path modDir, char* jsonBuf)
 
 	Name = modJson["Name"].GetString();
 
+	spdlog::info("Loading mod '{}'", Name);
+
 	if (modJson.HasMember("Description"))
 		Description = modJson["Description"].GetString();
 	else
@@ -157,7 +159,7 @@ void Mod::ParseConVars(rapidjson_document& json)
 
 		ConVars.push_back(convar);
 
-		spdlog::info("'{}' registered ConVar '{}'", Name, convar->Name);
+		spdlog::info("'{}' contains ConVar '{}'", Name, convar->Name);
 	}
 }
 

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -633,7 +633,7 @@ void ModManager::LoadMods()
 		if (m_bHasEnabledModsCfg && m_EnabledModsCfg.HasMember(mod.Name.c_str()))
 			mod.m_bEnabled = m_EnabledModsCfg[mod.Name.c_str()].IsTrue();
 		else
-			mod.m_bEnabled = false;
+			mod.m_bEnabled = true;
 
 		if (mod.m_bWasReadSuccessfully)
 		{

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -718,7 +718,7 @@ void ModManager::LoadMods()
 
 					ModVPKEntry& modVpk = mod.Vpks.emplace_back();
 					modVpk.m_bAutoLoad = !bUseVPKJson || (dVpkJson.HasMember("Preload") && dVpkJson["Preload"].IsObject() &&
-													  dVpkJson["Preload"].HasMember(vpkName) && dVpkJson["Preload"][vpkName].IsTrue());
+														  dVpkJson["Preload"].HasMember(vpkName) && dVpkJson["Preload"][vpkName].IsTrue());
 					modVpk.m_sVpkPath = (file.path().parent_path() / vpkName).string();
 
 					if (m_bHasLoadedMods && modVpk.m_bAutoLoad)

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -634,7 +634,7 @@ void ModManager::LoadMods()
 			mod.m_bEnabled = m_EnabledModsCfg[mod.Name.c_str()].IsTrue();
 		else
 			mod.m_bEnabled = false;
-		
+
 		if (mod.m_bWasReadSuccessfully)
 		{
 			if (mod.m_bEnabled)
@@ -718,7 +718,7 @@ void ModManager::LoadMods()
 
 					ModVPKEntry& modVpk = mod.Vpks.emplace_back();
 					modVpk.m_bAutoLoad = !bUseVPKJson || (dVpkJson.HasMember("Preload") && dVpkJson["Preload"].IsObject() &&
-						dVpkJson["Preload"].HasMember(vpkName) && dVpkJson["Preload"][vpkName].IsTrue());
+																							dVpkJson["Preload"].HasMember(vpkName) && dVpkJson["Preload"][vpkName].IsTrue());
 					modVpk.m_sVpkPath = (file.path().parent_path() / vpkName).string();
 
 					if (m_bHasLoadedMods && modVpk.m_bAutoLoad)
@@ -753,8 +753,8 @@ void ModManager::LoadMods()
 			if (bUseRpakJson && dRpakJson.HasMember("Aliases") && dRpakJson["Aliases"].IsObject())
 			{
 				for (rapidjson::Value::ConstMemberIterator iterator = dRpakJson["Aliases"].MemberBegin();
-					iterator != dRpakJson["Aliases"].MemberEnd();
-					iterator++)
+					 iterator != dRpakJson["Aliases"].MemberEnd();
+					 iterator++)
 				{
 					if (!iterator->name.IsString() || !iterator->value.IsString())
 						continue;
@@ -773,7 +773,7 @@ void ModManager::LoadMods()
 					ModRpakEntry& modPak = mod.Rpaks.emplace_back();
 					modPak.m_bAutoLoad =
 						!bUseRpakJson || (dRpakJson.HasMember("Preload") && dRpakJson["Preload"].IsObject() &&
-							dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
+														dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
 
 					// postload things
 					if (!bUseRpakJson ||

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -718,7 +718,7 @@ void ModManager::LoadMods()
 
 					ModVPKEntry& modVpk = mod.Vpks.emplace_back();
 					modVpk.m_bAutoLoad = !bUseVPKJson || (dVpkJson.HasMember("Preload") && dVpkJson["Preload"].IsObject() &&
-						dVpkJson["Preload"].HasMember(vpkName) && dVpkJson["Preload"][vpkName].IsTrue());
+													  dVpkJson["Preload"].HasMember(vpkName) && dVpkJson["Preload"][vpkName].IsTrue());
 					modVpk.m_sVpkPath = (file.path().parent_path() / vpkName).string();
 
 					if (m_bHasLoadedMods && modVpk.m_bAutoLoad)
@@ -773,7 +773,7 @@ void ModManager::LoadMods()
 					ModRpakEntry& modPak = mod.Rpaks.emplace_back();
 					modPak.m_bAutoLoad =
 						!bUseRpakJson || (dRpakJson.HasMember("Preload") && dRpakJson["Preload"].IsObject() &&
-							dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
+										  dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
 
 					// postload things
 					if (!bUseRpakJson ||

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -609,9 +609,6 @@ void ModManager::LoadMods()
 
 		Mod mod(modDir, (char*)jsonStringStream.str().c_str());
 
-		if (!mod.m_bEnabled)
-			continue;
-
 		for (auto& pair : mod.DependencyConstants)
 		{
 			if (m_DependencyConstants.find(pair.first) != m_DependencyConstants.end() && m_DependencyConstants[pair.first] != pair.second)

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -718,7 +718,7 @@ void ModManager::LoadMods()
 
 					ModVPKEntry& modVpk = mod.Vpks.emplace_back();
 					modVpk.m_bAutoLoad = !bUseVPKJson || (dVpkJson.HasMember("Preload") && dVpkJson["Preload"].IsObject() &&
-																							dVpkJson["Preload"].HasMember(vpkName) && dVpkJson["Preload"][vpkName].IsTrue());
+						dVpkJson["Preload"].HasMember(vpkName) && dVpkJson["Preload"][vpkName].IsTrue());
 					modVpk.m_sVpkPath = (file.path().parent_path() / vpkName).string();
 
 					if (m_bHasLoadedMods && modVpk.m_bAutoLoad)
@@ -773,7 +773,7 @@ void ModManager::LoadMods()
 					ModRpakEntry& modPak = mod.Rpaks.emplace_back();
 					modPak.m_bAutoLoad =
 						!bUseRpakJson || (dRpakJson.HasMember("Preload") && dRpakJson["Preload"].IsObject() &&
-														dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
+							dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
 
 					// postload things
 					if (!bUseRpakJson ||

--- a/NorthstarDLL/mods/modmanager.h
+++ b/NorthstarDLL/mods/modmanager.h
@@ -121,7 +121,7 @@ public:
 	std::unordered_map<std::string, std::string> DependencyConstants;
 
 public:
-	Mod(fs::path modPath, char* jsonBuf, rapidjson_document& enabledList);
+	Mod(fs::path modPath, char* jsonBuf);
 
 private:
 	void ParseConVars(rapidjson_document& json);

--- a/NorthstarDLL/mods/modmanager.h
+++ b/NorthstarDLL/mods/modmanager.h
@@ -15,7 +15,7 @@ const std::string COMPILED_ASSETS_SUFFIX = "/runtime/compiled";
 
 struct ModConVar
 {
-  public:
+public:
 	std::string Name;
 	std::string DefaultValue;
 	std::string HelpString;
@@ -24,7 +24,7 @@ struct ModConVar
 
 struct ModConCommand
 {
-  public:
+public:
 	std::string Name;
 	std::string Function;
 	std::string HelpString;
@@ -34,7 +34,7 @@ struct ModConCommand
 
 struct ModScriptCallback
 {
-  public:
+public:
 	ScriptContext Context;
 
 	// called before the codecallback is executed
@@ -47,7 +47,7 @@ struct ModScriptCallback
 
 struct ModScript
 {
-  public:
+public:
 	std::string Path;
 	std::string RunOn;
 
@@ -57,14 +57,14 @@ struct ModScript
 // these are pretty much identical, could refactor to use the same stuff?
 struct ModVPKEntry
 {
-  public:
+public:
 	bool m_bAutoLoad;
 	std::string m_sVpkPath;
 };
 
 struct ModRpakEntry
 {
-  public:
+public:
 	bool m_bAutoLoad;
 	std::string m_sPakName;
 	std::string m_sLoadAfterPak;
@@ -72,7 +72,7 @@ struct ModRpakEntry
 
 class Mod
 {
-  public:
+public:
 	// runtime stuff
 	bool m_bEnabled = true;
 	bool m_bWasReadSuccessfully = false;
@@ -120,20 +120,27 @@ class Mod
 
 	std::unordered_map<std::string, std::string> DependencyConstants;
 
-  public:
-	Mod(fs::path modPath, char* jsonBuf);
+public:
+	Mod(fs::path modPath, char* jsonBuf, rapidjson_document& enabledList);
+
+private:
+	void ParseConVars(rapidjson_document& json);
+	void ParseConCommands(rapidjson_document& json);
+	void ParseScripts(rapidjson_document& json);
+	void ParseLocalization(rapidjson_document& json);
+	void ParseDependencies(rapidjson_document& json);
 };
 
 struct ModOverrideFile
 {
-  public:
+public:
 	Mod* m_pOwningMod;
 	fs::path m_Path;
 };
 
 class ModManager
 {
-  private:
+private:
 	bool m_bHasLoadedMods = false;
 	bool m_bHasEnabledModsCfg;
 	rapidjson_document m_EnabledModsCfg;
@@ -143,12 +150,12 @@ class ModManager
 	size_t m_hPdefHash;
 	size_t m_hKBActHash;
 
-  public:
+public:
 	std::vector<Mod> m_LoadedMods;
 	std::unordered_map<std::string, ModOverrideFile> m_ModFiles;
 	std::unordered_map<std::string, std::string> m_DependencyConstants;
 
-  public:
+public:
 	ModManager();
 	void LoadMods();
 	void UnloadMods();

--- a/NorthstarDLL/mods/modmanager.h
+++ b/NorthstarDLL/mods/modmanager.h
@@ -15,7 +15,7 @@ const std::string COMPILED_ASSETS_SUFFIX = "/runtime/compiled";
 
 struct ModConVar
 {
-public:
+  public:
 	std::string Name;
 	std::string DefaultValue;
 	std::string HelpString;
@@ -24,7 +24,7 @@ public:
 
 struct ModConCommand
 {
-public:
+  public:
 	std::string Name;
 	std::string Function;
 	std::string HelpString;
@@ -34,7 +34,7 @@ public:
 
 struct ModScriptCallback
 {
-public:
+  public:
 	ScriptContext Context;
 
 	// called before the codecallback is executed
@@ -47,7 +47,7 @@ public:
 
 struct ModScript
 {
-public:
+  public:
 	std::string Path;
 	std::string RunOn;
 
@@ -57,14 +57,14 @@ public:
 // these are pretty much identical, could refactor to use the same stuff?
 struct ModVPKEntry
 {
-public:
+  public:
 	bool m_bAutoLoad;
 	std::string m_sVpkPath;
 };
 
 struct ModRpakEntry
 {
-public:
+  public:
 	bool m_bAutoLoad;
 	std::string m_sPakName;
 	std::string m_sLoadAfterPak;
@@ -72,7 +72,7 @@ public:
 
 class Mod
 {
-public:
+  public:
 	// runtime stuff
 	bool m_bEnabled = true;
 	bool m_bWasReadSuccessfully = false;
@@ -120,10 +120,10 @@ public:
 
 	std::unordered_map<std::string, std::string> DependencyConstants;
 
-public:
+  public:
 	Mod(fs::path modPath, char* jsonBuf);
 
-private:
+  private:
 	void ParseConVars(rapidjson_document& json);
 	void ParseConCommands(rapidjson_document& json);
 	void ParseScripts(rapidjson_document& json);
@@ -133,14 +133,14 @@ private:
 
 struct ModOverrideFile
 {
-public:
+  public:
 	Mod* m_pOwningMod;
 	fs::path m_Path;
 };
 
 class ModManager
 {
-private:
+  private:
 	bool m_bHasLoadedMods = false;
 	bool m_bHasEnabledModsCfg;
 	rapidjson_document m_EnabledModsCfg;
@@ -150,12 +150,12 @@ private:
 	size_t m_hPdefHash;
 	size_t m_hKBActHash;
 
-public:
+  public:
 	std::vector<Mod> m_LoadedMods;
 	std::unordered_map<std::string, ModOverrideFile> m_ModFiles;
 	std::unordered_map<std::string, std::string> m_DependencyConstants;
 
-public:
+  public:
 	ModManager();
 	void LoadMods();
 	void UnloadMods();


### PR DESCRIPTION
Separates mod loading into multiple functions to get rid of `goto`

~~Also stops parsing mod as soon as we can check whether it is enabled~~